### PR TITLE
Ble Local Name can be changed

### DIFF
--- a/android/src/main/java/com/vitorpamplona/bleadvertiser/BLEAdvertiserModule.java
+++ b/android/src/main/java/com/vitorpamplona/bleadvertiser/BLEAdvertiserModule.java
@@ -114,7 +114,7 @@ public class BLEAdvertiserModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void broadcast(String uid, ReadableArray payload, ReadableMap options, Promise promise) {
+    public void broadcast(String uid, ReadableArray payload, String localName, ReadableMap options, Promise promise) {
         if (mBluetoothAdapter == null) {
             Log.w("BLEAdvertiserModule", "Device does not support Bluetooth. Adapter is Null");
             promise.reject("Device does not support Bluetooth. Adapter is Null");
@@ -157,9 +157,13 @@ public class BLEAdvertiserModule extends ReactContextBaseJavaModule {
             promise.reject("Advertiser unavailable on this device");
             return;
         }
-        
+
         AdvertiseSettings settings = buildAdvertiseSettings(options);
         AdvertiseData data = buildAdvertiseData(uid != null ? ParcelUuid.fromString(uid) : null, toByteArray(payload), options);
+
+        if(localName != null) {
+            mBluetoothAdapter.setName(localName);
+        }
 
         tempAdvertiser.startAdvertising(settings, data, tempCallback);
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,7 +16,7 @@ export interface BroadcastOptions {
 }
 
 export function setCompanyId(companyId: number): void;
-export function broadcast(uid: String | null, manufData: number[], options?: BroadcastOptions): Promise<string>;
+export function broadcast(uid: String | null, manufData: number[], localName: String | null, options?: BroadcastOptions): Promise<string>;
 export function stopBroadcast(): Promise<string>;
 export function scan(manufDataFilter: number[], options?: ScanOptions): Promise<string>;
 export function scanByService(uidFilter: String, options?: ScanOptions): Promise<string>;


### PR DESCRIPTION
Hi,

I found your react-native-ble-advertiser fork pretty useful because having a service uuid in the advertising frame is not really convenient.

In my own project I also needed to modify the Ble Local Name which is advertised when you set "includeDeviceName" to true.

Here is the code I used for android devices. I do not have the skills to do the same for ios but maybe it could be a good future improvement.